### PR TITLE
fix: remove copying variable

### DIFF
--- a/cip20_test.go
+++ b/cip20_test.go
@@ -140,7 +140,7 @@ func TestValidCip20Metadata(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // capture range variable for goroutines
+		// capture range variable for goroutines
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
This is no longer necessary in modern Go. Verified using `go test -race`.