### PR TITLE
build: make targets for formatting and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# Determine root directory
+ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# Gather all .go files for use in dependencies below
+GO_FILES=$(shell find $(ROOT_DIR) -name '*.go')
+
+.PHONY: mod-tidy test format golines
+
+mod-tidy:
+	# Needed to fetch new dependencies and add them to go.mod
+	go mod tidy
+
+format:
+	go fmt ./...
+	gofmt -s -w $(GO_FILES)
+
+golines:
+	golines -w --ignore-generated --chain-split-dots --max-len=80 --reformat-tags .
+
+test: mod-tidy
+	go test -v -race ./...

--- a/cdns_test.go
+++ b/cdns_test.go
@@ -122,7 +122,10 @@ func TestCardanoDnsRoundTripLossless(t *testing.T) {
 		}
 		var dec models.CardanoDnsDomain
 		if _, err := cbor.Decode(enc, &dec); err != nil {
-			t.Fatalf("Failed to decode CBOR back into CardanoDnsDomain: %v", err)
+			t.Fatalf(
+				"Failed to decode CBOR back into CardanoDnsDomain: %v",
+				err,
+			)
 		}
 		if !reflect.DeepEqual(dec, testDef.expectedObj) {
 			t.Fatalf("CBOR round-trip failed\n  got: %s\n  want: %s",
@@ -135,7 +138,9 @@ func TestCardanoDnsRoundTripLossless(t *testing.T) {
 
 // It verifies that CardanoDnsMaybe encodes using constructor 0 for "Just(value)" and constructor 1 for "None".
 func TestCardanoDnsMaybe_Encode_Constructors(t *testing.T) {
-	just := models.NewCardanoDnsMaybe[models.CardanoDnsTtl](models.CardanoDnsTtl(60))
+	just := models.NewCardanoDnsMaybe[models.CardanoDnsTtl](
+		models.CardanoDnsTtl(60),
+	)
 	none := models.NewCardanoDnsMaybe[models.CardanoDnsTtl](nil)
 
 	// Encode Just(value) and verify whether it uses constructor 0
@@ -148,7 +153,10 @@ func TestCardanoDnsMaybe_Encode_Constructors(t *testing.T) {
 		t.Fatalf("Failed to decode CBOR for 'Just(value)': %v", err)
 	}
 	if jc.Constructor() != 0 {
-		t.Fatalf("Invalid constructor for 'Just(value)': got %d want 0", jc.Constructor())
+		t.Fatalf(
+			"Invalid constructor for 'Just(value)': got %d want 0",
+			jc.Constructor(),
+		)
 	}
 
 	// Encode "None" value and verify whether it uses constructor 1 or not
@@ -161,7 +169,10 @@ func TestCardanoDnsMaybe_Encode_Constructors(t *testing.T) {
 		t.Fatalf("Failed to decode CBOR for 'None' value: %v", err)
 	}
 	if nc.Constructor() != 1 {
-		t.Fatalf("Invalid constructor for 'None' value: got %d want 1", nc.Constructor())
+		t.Fatalf(
+			"Invalid constructor for 'None' value: got %d want 1",
+			nc.Constructor(),
+		)
 	}
 }
 
@@ -186,13 +197,23 @@ func TestCardanoDnsDomainRecord_Encode_RoundTrip(t *testing.T) {
 		t.Fatalf("Failed to decode CBOR into Constructor: %v", err)
 	}
 	if cons.Constructor() != 1 {
-		t.Fatalf("Invalid constructor tag for CardanoDnsDomainRecord: got %d want 1", cons.Constructor())
+		t.Fatalf(
+			"Invalid constructor tag for CardanoDnsDomainRecord: got %d want 1",
+			cons.Constructor(),
+		)
 	}
 	var got models.CardanoDnsDomainRecord
 	if _, err := cbor.Decode(enc, &got); err != nil {
-		t.Fatalf("Failed to decode constructor fields into CardanoDnsDomainRecord: %v", err)
+		t.Fatalf(
+			"Failed to decode constructor fields into CardanoDnsDomainRecord: %v",
+			err,
+		)
 	}
 	if !reflect.DeepEqual(got, rec) {
-		t.Fatalf("Round-trip mismatch for CardanoDnsDomainRecord:\n  got: %+v\n  want: %+v", got, rec)
+		t.Fatalf(
+			"Round-trip mismatch for CardanoDnsDomainRecord:\n  got: %+v\n  want: %+v",
+			got,
+			rec,
+		)
 	}
 }

--- a/cip25_test.go
+++ b/cip25_test.go
@@ -498,7 +498,9 @@ func TestCip25Metadata_RequiredFields(t *testing.T) {
 		policies := map[string]map[string]AssetMetadata{
 			"policy1": {
 				"asset1": {
-					Image: UriField{Uris: []string{"https://example.com/image.png"}},
+					Image: UriField{
+						Uris: []string{"https://example.com/image.png"},
+					},
 				},
 			},
 		}
@@ -541,11 +543,15 @@ func TestCip25Metadata_FilesValidation(t *testing.T) {
 			"policy1": {
 				"asset1": {
 					Name: "Test Asset",
-					Image: UriField{Uris: []string{"https://example.com/image.png"}},
+					Image: UriField{
+						Uris: []string{"https://example.com/image.png"},
+					},
 					Files: []FileDetails{
 						{
 							Name: "file1",
-							Src:  UriField{Uris: []string{"https://example.com/file1.png"}},
+							Src: UriField{
+								Uris: []string{"https://example.com/file1.png"},
+							},
 							// Missing MediaType
 						},
 					},
@@ -562,11 +568,15 @@ func TestCip25Metadata_FilesValidation(t *testing.T) {
 			"policy1": {
 				"asset1": {
 					Name: "Test Asset",
-					Image: UriField{Uris: []string{"https://example.com/image.png"}},
+					Image: UriField{
+						Uris: []string{"https://example.com/image.png"},
+					},
 					Files: []FileDetails{
 						{
 							MediaType: "image/png",
-							Src:       UriField{Uris: []string{"https://example.com/file1.png"}},
+							Src: UriField{
+								Uris: []string{"https://example.com/file1.png"},
+							},
 							// Missing Name
 						},
 					},
@@ -583,7 +593,9 @@ func TestCip25Metadata_FilesValidation(t *testing.T) {
 			"policy1": {
 				"asset1": {
 					Name: "Test Asset",
-					Image: UriField{Uris: []string{"https://example.com/image.png"}},
+					Image: UriField{
+						Uris: []string{"https://example.com/image.png"},
+					},
 					Files: []FileDetails{
 						{
 							Name:      "file1",
@@ -605,7 +617,9 @@ func TestCip25Metadata_VersionValidation(t *testing.T) {
 		"policy1": {
 			"asset1": {
 				Name: "Test Asset",
-				Image: UriField{Uris: []string{"https://example.com/image.png"}},
+				Image: UriField{
+					Uris: []string{"https://example.com/image.png"},
+				},
 			},
 		},
 	}
@@ -638,8 +652,10 @@ func TestCip25Metadata_MinimalValid(t *testing.T) {
 	policies := map[string]map[string]AssetMetadata{
 		"policy1": {
 			"asset1": {
-				Name:  "Test Asset",
-				Image: UriField{Uris: []string{"https://example.com/image.png"}},
+				Name: "Test Asset",
+				Image: UriField{
+					Uris: []string{"https://example.com/image.png"},
+				},
 			},
 		},
 	}
@@ -649,16 +665,26 @@ func TestCip25Metadata_MinimalValid(t *testing.T) {
 	require.Equal(t, 1, meta.Num721.Version)
 	require.Len(t, meta.Num721.Policies, 1)
 	require.Len(t, meta.Num721.Policies[HexBytes("policy1")], 1)
-	require.Equal(t, "Test Asset", meta.Num721.Policies[HexBytes("policy1")][HexBytes("asset1")].Name)
-	require.Equal(t, []string{"https://example.com/image.png"}, meta.Num721.Policies[HexBytes("policy1")][HexBytes("asset1")].Image.Uris)
+	require.Equal(
+		t,
+		"Test Asset",
+		meta.Num721.Policies[HexBytes("policy1")][HexBytes("asset1")].Name,
+	)
+	require.Equal(
+		t,
+		[]string{"https://example.com/image.png"},
+		meta.Num721.Policies[HexBytes("policy1")][HexBytes("asset1")].Image.Uris,
+	)
 }
 
 func TestCip25Metadata_Version1Vs2Keys(t *testing.T) {
 	policies := map[string]map[string]AssetMetadata{
 		"policy1": {
 			"asset1": {
-				Name:  "Test Asset",
-				Image: UriField{Uris: []string{"https://example.com/image.png"}},
+				Name: "Test Asset",
+				Image: UriField{
+					Uris: []string{"https://example.com/image.png"},
+				},
 			},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Makefile with targets for formatting and running tests to standardize local development. Reformatted test files to meet golines/gofmt rules; no functional changes.

- New Features
  - make test: runs go mod tidy then go test -v -race ./...
  - make format: runs go fmt and gofmt -s across all .go files
  - make golines: enforces 80-char lines and tag formatting

<sup>Written for commit f03d38f2444e7c3fb36521e312ed46df92520d35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling and test infrastructure with improved build automation and code formatting standards for maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->