### PR TITLE
fix: prealloc in tuna to appease golangci-lint

### DIFF
--- a/tuna.go
+++ b/tuna.go
@@ -33,7 +33,7 @@ type TunaV1State struct {
 }
 
 func (t *TunaV1State) MarshalCBOR() ([]byte, error) {
-	tmpInterlink := []any{}
+	tmpInterlink := make([]any, 0, len(t.Interlink))
 	for _, item := range t.Interlink {
 		tmpInterlink = append(tmpInterlink, item)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preallocates tmpInterlink in TunaV1State.MarshalCBOR with capacity len(t.Interlink) to satisfy golangci-lint’s prealloc rule and reduce allocations. No behavior change; minor performance and lint fix.

<sup>Written for commit bac38a416b0dffa02942b0e9fda97a8f2c48d799. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

