### PR TITLE
chore: test and build on Go 1.26

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
       - name: run nilaway


### PR DESCRIPTION
## Summary

The module already requires Go 1.25 (`go 1.25.7`); this completes the org-wide Go upgrade by also exercising it on **1.26**, matching the rest of the Blink Labs Go repos:

- `go-test.yml`: matrix `[1.25.x]` → `[1.25.x, 1.26.x]`
- `golangci-lint.yml`, `nilaway.yml`: `1.25.x` → `1.26.x`

`go.mod` is unchanged (already at the 1.25 minimum).

## Verification

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l`, and `golangci-lint run ./...` (0 issues) all pass locally on Go 1.26.

Part of the org-wide Go 1.25 upgrade (blinklabs-io/issues#120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CI now tests and lints on Go 1.26 alongside 1.25 to align with the org-wide Go upgrade. Added 1.26 to the `go-test.yml` matrix and switched `golangci-lint.yml` and `nilaway.yml` to 1.26; `go.mod` stays at the 1.25 minimum.

<sup>Written for commit acf76c7f6dd5efff564cdd5479b1bd157cb24c38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/cardano-models/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

